### PR TITLE
Sync rust cpython and tox

### DIFF
--- a/example/extensions/Cargo.lock
+++ b/example/extensions/Cargo.lock
@@ -2,40 +2,124 @@
 name = "hello-world"
 version = "0.0.1"
 dependencies = [
- "cpython 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "interpolate_idents 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cpython 0.0.5 (git+https://github.com/dgrunwald/rust-cpython.git?rev=e644f24)",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cpython"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.0.5"
+source = "git+https://github.com/dgrunwald/rust-cpython.git?rev=e644f24#e644f24a2bb8e0b51a0d1f5d947ff7a1cd929ecc"
 dependencies = [
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "python27-sys 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "python3-sys 0.1.2 (git+https://github.com/dgrunwald/rust-cpython.git?rev=e644f24)",
 ]
 
 [[package]]
-name = "interpolate_idents"
-version = "0.0.3"
+name = "kernel32-sys"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "libc"
-version = "0.1.8"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "pkg-config"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "python27-sys"
-version = "0.0.6"
+name = "memchr"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "num-traits"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "python3-sys"
+version = "0.1.2"
+source = "git+https://github.com/dgrunwald/rust-cpython.git?rev=e644f24#e644f24a2bb8e0b51a0d1f5d947ff7a1cd929ecc"
+dependencies = [
+ "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex"
+version = "0.1.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "thread-id"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "utf8-ranges"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[metadata]
+"checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
+"checksum cpython 0.0.5 (git+https://github.com/dgrunwald/rust-cpython.git?rev=e644f24)" = "<none>"
+"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+"checksum libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "a51822fc847e7a8101514d1d44e354ba2ffa7d4c194dcab48870740e327cac70"
+"checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
+"checksum num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "a16a42856a256b39c6d3484f097f6713e14feacd9bfb02290917904fae46c81c"
+"checksum python3-sys 0.1.2 (git+https://github.com/dgrunwald/rust-cpython.git?rev=e644f24)" = "<none>"
+"checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
+"checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
+"checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
+"checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
+"checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
+"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/example/extensions/Cargo.toml
+++ b/example/extensions/Cargo.toml
@@ -4,6 +4,10 @@ name = "hello-world"
 version = "0.0.1"
 authors = ["James Salter <iteration@gmail.com>"]
 
+[features]
+python27-sys = ["cpython/python27-sys"]
+python3-sys = ["cpython/python3-sys"]
+
 [dependencies.cpython]
 git = "https://github.com/dgrunwald/rust-cpython.git"
 rev = "e644f24"

--- a/example/extensions/Cargo.toml
+++ b/example/extensions/Cargo.toml
@@ -4,10 +4,11 @@ name = "hello-world"
 version = "0.0.1"
 authors = ["James Salter <iteration@gmail.com>"]
 
-[dependencies]
-cpython = "*"
-interpolate_idents = "0.0.3"
+[dependencies.cpython]
+git = "https://github.com/dgrunwald/rust-cpython.git"
+rev = "e644f24"
+default-features = false
 
 [lib]
 name = "helloworld"
-crate-type = ["dylib"]
+crate-type = ["cdylib"]

--- a/example/hello_rust/__init__.py
+++ b/example/hello_rust/__init__.py
@@ -1,3 +1,3 @@
 def hello():
     import helloworld
-    helloworld.run()
+    helloworld.run(helloworld.val())

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+def test_hello():
+    import hello_rust
+    hello_rust.hello()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py27, py35
+
+[testenv]
+commands =
+    python setup.py install
+    pip install example/
+    py.test
+deps =
+    pytest


### PR DESCRIPTION
Hi, I have updated some stuff in your repo, and added a minimal `tox` setup that runs correctly on my Ubuntu `yakkety`.

I was not able to add Travis support, because as shown in the [build logs](https://travis-ci.org/naufraghi/rust-python-ext/jobs/184931724#L370), cargo has some problem building on the Travis `rust` image.

TL;DR the error is this:
```
/usr/bin/ld: /tmp/pip-aLptQD-build/extensions/target/release/deps/libpython27_sys-40ee1ffc0b273edb.rlib(abstract.o): relocation R_X86_64_32 against `.rodata.str1.8' can not be used when making a shared object; recompile with -fPIC
```