### PR TITLE
Travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,67 @@
+matrix:
+  allow_failures:
+    os: osx
+  include:
+    # Execute this code installing *cogapp* from PyPI and then:
+    # `cog.py -r .travis.yml` to update inplace.
+    # Notes:
+    #  - tox manages the python matrix
+    #  - the linux image has most python versions preinstalled
+    #  - brew installs the required versions on osx
+    #[[[cog
+    #import cog
+    #template = """\
+    #- language: generic
+    #  os: osx
+    #  python: 2.7
+    #  env:
+    #    - RUST_VERSION={rustver}
+    #- language: python
+    #  python: 2.7
+    #  env:
+    #    - RUST_VERSION={rustver}\
+    #"""
+    #for rustver in ('stable', 'beta', 'nightly'):
+    #    cog.outl(template.format(**locals()))
+    #]]]
+    - language: generic
+      os: osx
+      python: 2.7
+      env:
+        - RUST_VERSION=stable
+    - language: python
+      python: 2.7
+      env:
+        - RUST_VERSION=stable
+    - language: generic
+      os: osx
+      python: 2.7
+      env:
+        - RUST_VERSION=beta
+    - language: python
+      python: 2.7
+      env:
+        - RUST_VERSION=beta
+    - language: generic
+      os: osx
+      python: 2.7
+      env:
+        - RUST_VERSION=nightly
+    - language: python
+      python: 2.7
+      env:
+        - RUST_VERSION=nightly
+    #[[[end]]]
+
+#  Manually install python on osx
+before_install:
+  - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then ci/osx-install.sh; fi
+
+install:
+  - curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUST_VERSION
+  - export PATH="$HOME/.cargo/bin:$PATH"
+  - rustc -V
+script:
+  - sudo pip install tox
+  - tox
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: cog
+
+cog: .travis.yml
+	cog.py -r .travis.yml

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # rust-python-ext
+
+[![Build Status](https://travis-ci.org/novocaine/rust-python-ext.svg?branch=master)](https://travis-ci.org/novocaine/rust-python-ext)
+
 Setuptools helpers for rust Python extensions.
 
 Compile and distribute Python extensions written in rust as easily as if they were written in C. 

--- a/ci/osx-install.sh
+++ b/ci/osx-install.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+brew tap zoidbergwill/python
+brew install python35


### PR DESCRIPTION
Enable travis tests on linux and osx, python 2.7 and 3.5. Here the build results: https://travis-ci.org/naufraghi/rust-python-ext/builds/196651201

The tracking issue is: #9 

@novocaine the badge is already pointing your repo, you'll need to enable the Travis-GitHub integration on the repo.